### PR TITLE
Fix for Errno::ENAMETOOLONG due to query string

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,6 +38,9 @@ Style/PercentLiteralDelimiters:
 Metrics/AbcSize:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 AllCops:
   Exclude:
     - 'Guardfile'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ notifications:
 script: bundle exec rake travis
 cache: bundler
 rvm:
-  - 2.1
-  - 2.2
+  - 2.2.5
+  - 2.3.1
 branches:
   only:
     - master

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ gem 'poise', '~> 2.2'
 gem 'poise-boiler'
 
 group :lint do
-  gem 'rubocop'
   gem 'foodcritic'
+  gem 'rubocop'
 end
 
 group :unit do

--- a/libraries/libartifact_file.rb
+++ b/libraries/libartifact_file.rb
@@ -42,12 +42,12 @@ module LibArtifactCookbook
       action(:create) do
         include_recipe 'libarchive::default'
         notifying_block do
-          extension = ::File.extname(new_resource.remote_url)
+          extension = ::File.extname(::URI.parse(new_resource.remote_url).path)
           friendly_name = "#{new_resource.artifact_name}-#{new_resource.artifact_version}#{extension}"
 
           directory ::File.join(new_resource.install_path, new_resource.artifact_name) do
-            owner new_resource.owner
-            group new_resource.group
+            owner new_resource.owner if new_resource.owner
+            group new_resource.group if new_resource.group
             mode '0755'
           end
 
@@ -63,8 +63,8 @@ module LibArtifactCookbook
             action :extract
             extract_to new_resource.release_path
             extract_options new_resource.extract_options
-            owner new_resource.owner
-            group new_resource.group
+            owner new_resource.owner if new_resource.owner
+            group new_resource.group if new_resource.group
             not_if { ::File.exist? new_resource.release_path }
           end
 

--- a/test/fixtures/twbs/attributes/default.rb
+++ b/test/fixtures/twbs/attributes/default.rb
@@ -1,4 +1,4 @@
 default['twbs']['version'] = '3.3.4'
 default['twbs']['checksum'] = '9af5ebe4e079ac0a07d6785852b62342ac38ef8186352e7ad1f534a16e7a0672'
 
-default['twbs']['remote_url'] = "https://github.com/twbs/bootstrap/releases/download/v%{version}/bootstrap-%{version}-dist.zip"
+default['twbs']['remote_url'] = "https://github.com/twbs/bootstrap/releases/download/v%{version}/bootstrap-%{version}-dist.zip?testquery=true"


### PR DESCRIPTION
Parse `remote_url` parameter with the URI library prior to determining
file extension, in order to avoid adding URL query strings to the file
extension. When using AWS pre-signed URLs, for example, the query string
is long enough to cause Chef to error out with `Errno::ENAMETOOLONG`.

Also add guards for user and group parameters, to remove deprecation
errors, and updated test with a query string.